### PR TITLE
add '__attribute__((weak))' to assert_failed(), so it can be overrided.

### DIFF
--- a/ilg.gnuarmeclipse.templates.core/templates/common/system/src/newlib/assert.c
+++ b/ilg.gnuarmeclipse.templates.core/templates/common/system/src/newlib/assert.c
@@ -38,7 +38,7 @@ __assert_func (const char *file, int line, const char *func,
 #if defined(USE_FULL_ASSERT)
 
 void
-assert_failed (uint8_t* file, uint32_t line);
+assert_failed (uint8_t* file, uint32_t line) __attribute__((weak));
 
 // Called from the assert_param() macro, usually defined in the stm32f*_conf.h
 void


### PR DESCRIPTION
Thank you very much that this repo has its place on github.

I have my own customised assert_failed function, which logs on usart. It would be nice if the template can allow it be done alternatively. 

I am not quite a GDB guy, even through I know it is quite powerful. And I have no idea about how to play with stlink, d-link tools... My approach is more the 'burn and run' style. A few blinking leds and usart logging would do most of the job for me. 