### PR TITLE
Fix parent pom versions for PyOCD plug-ins

### DIFF
--- a/ilg.gnuarmeclipse.debug.gdbjtag.pyocd-feature/pom.xml
+++ b/ilg.gnuarmeclipse.debug.gdbjtag.pyocd-feature/pom.xml
@@ -11,7 +11,7 @@
   <parent>
   	<groupId>ilg.gnuarmeclipse</groupId>
   	<artifactId>ilg.gnuarmeclipse.parent</artifactId>
-  	<version>2.9.3-SNAPSHOT</version>
+  	<version>2.12.2-SNAPSHOT</version>
   	<relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/ilg.gnuarmeclipse.debug.gdbjtag.pyocd/pom.xml
+++ b/ilg.gnuarmeclipse.debug.gdbjtag.pyocd/pom.xml
@@ -11,7 +11,7 @@
   <parent>
   	<groupId>ilg.gnuarmeclipse</groupId>
   	<artifactId>ilg.gnuarmeclipse.parent</artifactId>
-  	<version>2.9.3-SNAPSHOT</version>
+  	<version>2.12.2-SNAPSHOT</version>
   	<relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
The pyocd plug-ins are building against another version of the parent. 

Without this change the code does not build with maven with this error:

```
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for ilg.gnuarmeclipse:ilg.gnuarmeclipse.debug.gdbjtag.pyocd:0.2.0-SNAPSHOT: Could not find artifact ilg.gnuarmeclipse:ilg.gnuarmeclipse.parent:pom:2.9.3-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 11, column 11
[FATAL] Non-resolvable parent POM for ilg.gnuarmeclipse.features:ilg.gnuarmeclipse.debug.gdbjtag.pyocd:0.2.0-SNAPSHOT: Could not find artifact ilg.gnuarmeclipse:ilg.gnuarmeclipse.parent:pom:2.9.3-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 11, column 11
 @ 
[ERROR] The build could not read 2 projects -> [Help 1]
[ERROR]   
[ERROR]   The project ilg.gnuarmeclipse:ilg.gnuarmeclipse.debug.gdbjtag.pyocd:0.2.0-SNAPSHOT (/scratch/armgnu/git/plug-ins/ilg.gnuarmeclipse.debug.gdbjtag.pyocd/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM for ilg.gnuarmeclipse:ilg.gnuarmeclipse.debug.gdbjtag.pyocd:0.2.0-SNAPSHOT: Could not find artifact ilg.gnuarmeclipse:ilg.gnuarmeclipse.parent:pom:2.9.3-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 11, column 11 -> [Help 2]
[ERROR]   
[ERROR]   The project ilg.gnuarmeclipse.features:ilg.gnuarmeclipse.debug.gdbjtag.pyocd:0.2.0-SNAPSHOT (/scratch/armgnu/git/plug-ins/ilg.gnuarmeclipse.debug.gdbjtag.pyocd-feature/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM for ilg.gnuarmeclipse.features:ilg.gnuarmeclipse.debug.gdbjtag.pyocd:0.2.0-SNAPSHOT: Could not find artifact ilg.gnuarmeclipse:ilg.gnuarmeclipse.parent:pom:2.9.3-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 11, column 11 -> [Help 2]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException


```
