### PR TITLE
Issue 126 Preferences Global Tools Paths and Workspace Tools Paths do…

### DIFF
--- a/ilg.gnuarmeclipse.core/src/ilg/gnuarmeclipse/core/preferences/DirectoryNotStrictFieldEditor.java
+++ b/ilg.gnuarmeclipse.core/src/ilg/gnuarmeclipse/core/preferences/DirectoryNotStrictFieldEditor.java
@@ -31,6 +31,7 @@ public class DirectoryNotStrictFieldEditor extends DirectoryFieldEditor {
 			String toolsPaths_label, Composite fieldEditorParent,
 			boolean isStrict) {
 		super(buildToolsPathKey, toolsPaths_label, fieldEditorParent);
+		fIsStrict = isStrict;
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
This patch fixes the following issue:

  [Preferences Global Tools Paths and Workspace Tools Paths don't honour strict folder check ](https://github.com/gnuarmeclipse/plug-ins/issues/126)

With this patch in place the expected behaviour in the "Steps to Reproduce" section of issue126 is observed.
