### PR TITLE
Issue 125 Project properties Tools Paths does not support eclipse variables

### DIFF
--- a/ilg.gnuarmeclipse.core/src/ilg/gnuarmeclipse/core/preferences/DirectoryNotStrictFieldEditor.java
+++ b/ilg.gnuarmeclipse.core/src/ilg/gnuarmeclipse/core/preferences/DirectoryNotStrictFieldEditor.java
@@ -31,6 +31,7 @@ public class DirectoryNotStrictFieldEditor extends DirectoryFieldEditor {
 			String toolsPaths_label, Composite fieldEditorParent,
 			boolean isStrict) {
 		super(buildToolsPathKey, toolsPaths_label, fieldEditorParent);
+		fIsStrict = isStrict;
 	}
 
 	// ------------------------------------------------------------------------

--- a/ilg.gnuarmeclipse.managedbuild.cross/src/ilg/gnuarmeclipse/managedbuild/cross/properties/ProjectToolsPathPropertyPage.java
+++ b/ilg.gnuarmeclipse.managedbuild.cross/src/ilg/gnuarmeclipse/managedbuild/cross/properties/ProjectToolsPathPropertyPage.java
@@ -13,13 +13,14 @@ package ilg.gnuarmeclipse.managedbuild.cross.properties;
 
 import ilg.gnuarmeclipse.core.EclipseUtils;
 import ilg.gnuarmeclipse.core.ScopedPreferenceStoreWithoutDefaults;
+import ilg.gnuarmeclipse.core.preferences.DirectoryNotStrictFieldEditor;
 import ilg.gnuarmeclipse.core.preferences.LabelFakeFieldEditor;
 import ilg.gnuarmeclipse.core.ui.FieldEditorPropertyPage;
 import ilg.gnuarmeclipse.managedbuild.cross.Activator;
 import ilg.gnuarmeclipse.managedbuild.cross.Option;
+import ilg.gnuarmeclipse.managedbuild.cross.ui.DefaultPreferences;
 import ilg.gnuarmeclipse.managedbuild.cross.ui.Messages;
 import ilg.gnuarmeclipse.managedbuild.cross.ui.PersistentPreferences;
-
 import java.util.HashSet;
 import java.util.Set;
 
@@ -29,7 +30,6 @@ import org.eclipse.cdt.managedbuilder.core.IOption;
 import org.eclipse.cdt.managedbuilder.core.IToolChain;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ProjectScope;
-import org.eclipse.jface.preference.DirectoryFieldEditor;
 import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.IPreferenceStore;
 
@@ -61,10 +61,11 @@ public class ProjectToolsPathPropertyPage extends FieldEditorPropertyPage {
 
 	@Override
 	protected void createFieldEditors() {
-
-		FieldEditor buildToolsPathField = new DirectoryFieldEditor(
+		boolean isStrict = DefaultPreferences.getBoolean(
+				PersistentPreferences.PROJECT_BUILDTOOLS_PATH_STRICT, true);
+		FieldEditor buildToolsPathField = new DirectoryNotStrictFieldEditor(
 				PersistentPreferences.BUILD_TOOLS_PATH_KEY,
-				Messages.ToolsPaths_label, getFieldEditorParent());
+				Messages.ToolsPaths_label, getFieldEditorParent(), isStrict);
 		addField(buildToolsPathField);
 
 		Set<String> toolchainNames = new HashSet<String>();
@@ -108,9 +109,11 @@ public class ProjectToolsPathPropertyPage extends FieldEditorPropertyPage {
 					getFieldEditorParent());
 			addField(labelField);
 
+			isStrict = DefaultPreferences.getBoolean(
+					PersistentPreferences.PROJECT_TOOLCHAIN_PATH_STRICT, true);
 			String key = PersistentPreferences.getToolchainKey(toolchainName);
-			FieldEditor toolchainPathField = new DirectoryFieldEditor(key,
-					Messages.ToolchainPaths_label, getFieldEditorParent());
+			FieldEditor toolchainPathField = new DirectoryNotStrictFieldEditor(
+					key, Messages.ToolchainPaths_label, getFieldEditorParent(), isStrict);
 			addField(toolchainPathField);
 		}
 	}

--- a/ilg.gnuarmeclipse.managedbuild.cross/src/ilg/gnuarmeclipse/managedbuild/cross/ui/PersistentPreferences.java
+++ b/ilg.gnuarmeclipse.managedbuild.cross/src/ilg/gnuarmeclipse/managedbuild/cross/ui/PersistentPreferences.java
@@ -37,6 +37,8 @@ public class PersistentPreferences {
 	public static final String GLOBAL_BUILDTOOLS_PATH_STRICT = "global.buildTools.path.strict";
 	public static final String WORKSPACE_TOOLCHAIN_PATH_STRICT = "workspace.toolchain.path.strict";
 	public static final String WORKSPACE_BUILDTOOLS_PATH_STRICT = "workspace.buildTools.path.strict";
+	public static final String PROJECT_TOOLCHAIN_PATH_STRICT = "project.toolchain.path.strict";
+	public static final String PROJECT_BUILDTOOLS_PATH_STRICT = "project.buildTools.path.strict";
 	
 	// Note: The shared defaults keys don't have "cross" in them because we want
 	// to keep


### PR DESCRIPTION
This patch fixes the following issue:
  Issue 125 Project properties Tools Paths does not support eclipse variables
  https://github.com/gnuarmeclipse/plug-ins/issues/125

With this patch in place, and the additional preferences specified below*, the expected behaviour in the "Steps to Reproduce" section of issue125 is observed.

*: Preferences.
To turn off strict folder checking in "Project properties > C/C++ Build > Tools Paths" add the following to Eclipse product with a preferenceCustomization file (eg: "plugin_customization.ini") using extension point org.eclipse.core.runtime.products:

  ilg.gnuarmeclipse.managedbuild.cross/project.toolchain.path.strict=false
  ilg.gnuarmeclipse.managedbuild.cross/project.buildTools.path.strict=false

Note, the following help page should be updated:
  http://gnuarmeclipse.github.io/developer/preferences/ilg.gnuarmeclipse.managedbuild.cross/#defaults
With these additions:

project.toolchain.path.strict=true
project.buildTools.path.strict=true
